### PR TITLE
TCXB8-3706 : SYS_SH_Syseventd_restart marker

### DIFF
--- a/source/pwrMgr.c
+++ b/source/pwrMgr.c
@@ -70,10 +70,10 @@
 /**************************************************************************/
 /*      LOCAL VARIABLES:                                                  */
 /**************************************************************************/
-static int sysevent_fd;
+static int sysevent_fd = -1;
 static token_t sysevent_token;
 static pthread_t sysevent_tid;
-static int sysevent_fd_gs;
+static int sysevent_fd_gs = -1;
 static token_t sysevent_token_gs;
 
 #ifdef INCLUDE_BREAKPAD
@@ -341,35 +341,29 @@ static bool PwrMgr_Register_sysevent()
 
     do
     {
-        sysevent_fd = sysevent_open("127.0.0.1", SE_SERVER_WELL_KNOWN_PORT, SE_VERSION, "rdkb_power_manger", &sysevent_token);
         if (sysevent_fd < 0)
-        {
-            PWRMGRLOG(ERROR, "rdkb_power_manager failed to register with sysevent daemon\n");
-            status = false;
-        }
-        else
-        {  
-            PWRMGRLOG(INFO, "rdkb_power_manager registered with sysevent daemon successfully\n");
-            status = true;
-        }
+	{
+	    sysevent_fd = sysevent_open("127.0.0.1", SE_SERVER_WELL_KNOWN_PORT, SE_VERSION, "rdkb_power_manger", &sysevent_token);
+	}
 
         //Make another connection for gets/sets
-        sysevent_fd_gs = sysevent_open("127.0.0.1", SE_SERVER_WELL_KNOWN_PORT, SE_VERSION, "rdkb_power_manager-gs", &sysevent_token_gs);
         if (sysevent_fd_gs < 0)
-        {
-            PWRMGRLOG(ERROR, "rdkb_power_manager-gs failed to register with sysevent daemon\n");
-            status = false;
-        }
-        else
-        {
-            PWRMGRLOG(INFO, "rdkb_power_manager-gs registered with sysevent daemon successfully\n");
-            status = true;
-        }
+	{
+	    sysevent_fd_gs = sysevent_open("127.0.0.1", SE_SERVER_WELL_KNOWN_PORT, SE_VERSION, "rdkb_power_manager-gs", &sysevent_token_gs);
+	}
 
-        if(status == false) {
-        	v_secure_system("/usr/bin/syseventd");
-                sleep(5);
+        if((sysevent_fd < 0) || (sysevent_fd_gs < 0))
+	{
+            PWRMGRLOG(ERROR, "rdkb_power_manger or rdkb_power_manager-gs failed to register with sysevent daemon\n");
+            status = false;
+            sleep(5);
         }
+	else
+	{
+            PWRMGRLOG(INFO, "rdkb_power_manger and rdkb_power_manager-gs registered with sysevent daemon successfully\n");
+            status = true;
+	}
+
     }while((status == false) && (retry++ < max_retries));
 
     if (status != false)


### PR DESCRIPTION
TCXB8-3706 : SYS_SH_Syseventd_restart marker
Reason for change: syseventd must not be started,
                   even if sysevent_open() fails
Test Procedure: refer to jira
Risks: Low
Priority:P1
Signed-off-by: abhishek_kumaracee2@comcast.com